### PR TITLE
fix: root node role update

### DIFF
--- a/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
+++ b/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
@@ -72,7 +72,7 @@ public class RolesAndPermissionsHandler implements Serializable {
     private static final long serialVersionUID = 7910715831938629654L;
 
     private static final Logger logger = LoggerFactory.getLogger(RolesAndPermissionsHandler.class);
-    
+
     private static final Pattern PATTERN_UNDERSCORE_DASH = Pattern.compile("[_-]");
 
     private static final Pattern PATTERN_UPPERCASE_LETTER = Pattern.compile("([A-Z])");
@@ -540,7 +540,7 @@ public class RolesAndPermissionsHandler implements Serializable {
 
         Map<String, String> allGroups = new HashMap<String, String>();
         for (String s : permissions.get(scope).keySet()) {
-            for (String s1 : Arrays.asList(s.split(","))) {
+            for (String s1 : s.split(",")) {
                 allGroups.put(s1, s);
             }
         }
@@ -718,7 +718,7 @@ public class RolesAndPermissionsHandler implements Serializable {
     }
 
     private void populateTitleAndDescription(PermissionBean bean) {
-        String localName = bean.getName().contains(":") ? StringUtils.substringAfter(bean.getName(), ":") : bean.getName(); 
+        String localName = bean.getName().contains(":") ? StringUtils.substringAfter(bean.getName(), ":") : bean.getName();
         if (localName.contains(":")) {
             localName = StringUtils.substringAfter(localName, ":");
         }
@@ -801,9 +801,7 @@ public class RolesAndPermissionsHandler implements Serializable {
 
     public void removeContext(String scope) throws RepositoryException {
 
-        if (roleBean.getPermissions().containsKey(scope)) {
-            roleBean.getPermissions().remove(scope);
-        }
+        roleBean.getPermissions().remove(scope);
         if (currentContext.equals(scope)) {
             setCurrentContext(roleBean.getPermissions().keySet().iterator().next());
         }
@@ -843,7 +841,7 @@ public class RolesAndPermissionsHandler implements Serializable {
                 role.setProperty("j:permissionNames", permissions.get("current").toArray(new Value[permissions.get("current").size()]));
             } else {
                 if (key.equals("/")) {
-                    key = "root-access";
+                    key = "rootNode-access";
                 } else {
                     key = ISO9075.encode((key.startsWith("/") ? key.substring(1) : key).replace("/", "-")) + "-access";
                 }


### PR DESCRIPTION
### Description
The name of the role updated on roles applied on root node wasn't the right one
`root-access` instead of `rootNode-access` as defined from [Jahia core](https://github.com/Jahia/jahia-private/blob/8526ca39c5e01b972f83b6b55aca9a6389ada1b0/war/src/main/webapp/WEB-INF/etc/repository/root-roles.xml#L120) 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
