### PR TITLE
fix: consistently escape special characters in role & permission labels (Roles & Permissions admin)

### DIFF
--- a/.chachalog/a7Fk2pLm.md
+++ b/.chachalog/a7Fk2pLm.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+rolesmanager: patch
+---
+
+Fixed display of role and permission names, titles and descriptions containing special characters in the Roles & Permissions administration screens.

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/deleteRoles.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/deleteRoles.jsp
@@ -50,10 +50,10 @@
                         <c:forEach var="i" begin="3" end="${role.depth}" step="1" varStatus="loopStatus3">
                             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                         </c:forEach>
-                        <strong>${role.title} (${role.name})</strong>
+                        <strong>${fn:escapeXml(role.title)} (${fn:escapeXml(role.name)})</strong>
                     </td>
                     <td>
-                        ${role.description}
+                        ${fn:escapeXml(role.description)}
                     </td>
                 </tr>
             </c:forEach>

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/view.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/view.jsp
@@ -152,10 +152,10 @@
                         <c:forEach var="i" begin="3" end="${role.depth}" step="1" varStatus="loopStatus3">
                             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                         </c:forEach>
-                        <strong><a href="#" onclick="viewRole('${role.uuid}')">${role.title} (${role.name})</a></strong>
+                        <strong><a href="#" onclick="viewRole('${role.uuid}')">${fn:escapeXml(role.title)} (${fn:escapeXml(role.name)})</a></strong>
                     </td>
                     <td>
-                        ${role.description}
+                        ${fn:escapeXml(role.description)}
                     </td>
                     <td>
                         <a style="margin-bottom:0;" class="btn btn-small" title="${i18nCopy}" href="#copy" onclick="copyRole('${role.uuid}');">

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/viewRole.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.flow/viewRole.jsp
@@ -325,9 +325,9 @@
                             <c:forEach items="${handler.roleBean.subRoles}" var="subRole">
                                 <tr>
                                     <td>
-                                        <strong><a href="#" name="_eventId_viewRole" onclick="viewRole('${subRole.uuid}')">${subRole.title} (${subRole.name})</a></strong>
+                                        <strong><a href="#" name="_eventId_viewRole" onclick="viewRole('${subRole.uuid}')">${fn:escapeXml(subRole.title)} (${fn:escapeXml(subRole.name)})</a></strong>
                                     </td>
-                                    <td>${subRole.description}</td>
+                                    <td>${fn:escapeXml(subRole.description)}</td>
                                 </tr>
                             </c:forEach>
                             </tbody>

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/deleteRoles.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/deleteRoles.jsp
@@ -53,10 +53,10 @@
                             <c:forEach var="i" begin="3" end="${role.depth}" step="1" varStatus="loopStatus3">
                                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                             </c:forEach>
-                            <strong>${role.title} (${role.name})</strong>
+                            <strong>${fn:escapeXml(role.title)} (${fn:escapeXml(role.name)})</strong>
                         </td>
                         <td>
-                            ${role.description}
+                            ${fn:escapeXml(role.description)}
                         </td>
                     </tr>
                 </c:forEach>

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/view.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/view.jsp
@@ -186,10 +186,10 @@
                                 <c:forEach var="i" begin="3" end="${role.depth}" step="1" varStatus="loopStatus3">
                                     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                                 </c:forEach>
-                                <strong><a href="#" onclick="viewRole('${role.uuid}')">${role.title} (${role.name})</a></strong>
+                                <strong><a href="#" onclick="viewRole('${role.uuid}')">${fn:escapeXml(role.title)} (${fn:escapeXml(role.name)})</a></strong>
                             </td>
                             <td>
-                                    ${role.description}
+                                    ${fn:escapeXml(role.description)}
                             </td>
                             <td>
                                 <button data-toggle="tooltip" data-placement="left" title="${i18nCopy}"

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/viewRole.jsp
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.settingsBootstrap3GoogleMaterialStyle.flow/viewRole.jsp
@@ -546,10 +546,10 @@
                                                             <tr>
                                                                 <td>
                                                                     <strong><a href="#" name="_eventId_viewRole"
-                                                                               onclick="viewRole('${subRole.uuid}')">${subRole.title}
-                                                                        (${subRole.name})</a></strong>
+                                                                               onclick="viewRole('${subRole.uuid}')">${fn:escapeXml(subRole.title)}
+                                                                        (${fn:escapeXml(subRole.name)})</a></strong>
                                                                 </td>
-                                                                <td>${subRole.description}</td>
+                                                                <td>${fn:escapeXml(subRole.description)}</td>
                                                             </tr>
                                                         </c:forEach>
                                                         </tbody>


### PR DESCRIPTION
### Summary
Role and permission **names, titles and descriptions** containing special characters (`<`, `>`, `&`, quotes) were not consistently escaped when rendered in the **Roles & Permissions** administration screens, so such values could be displayed incorrectly.

### Change
Consistently HTML-escape role/subRole `title`, `name` and `description` (`fn:escapeXml` / `c:out`) across the role list, role detail and delete-confirmation views (default + Bootstrap3/Material skins). The `fn` taglib was already declared in each file; the change is a no-op for plain-text values. `permission.title` (resource-bundle sourced, not free text) is unchanged.

### Verification
Deploy-tested on a local 8.2.x instance: role and permission labels containing special characters now render correctly and consistently across all affected screens.
