### PR TITLE
fix: copy a role with the caller's session

### DIFF
--- a/.chachalog/Q3BlNJhm.md
+++ b/.chachalog/Q3BlNJhm.md
@@ -2,4 +2,4 @@
 rolesmanager: patch
 ---
 
-Copying a role now runs on the caller session, the same way creating one already does, so both paths ask the operator for the same rights. The identifier submitted with the copy must designate a role stored under /roles; anything else is refused with a message.
+Copying a role requires the same rights as creating one, and the identifier submitted with the copy must designate a role stored under /roles; anything else is refused with a message.

--- a/.chachalog/Q3BlNJhm.md
+++ b/.chachalog/Q3BlNJhm.md
@@ -1,0 +1,5 @@
+---
+rolesmanager: patch
+---
+
+Copying a role now runs on the caller session, the same way creating one already does, so both paths ask the operator for the same rights. The identifier submitted with the copy must designate a role stored under /roles; anything else is refused with a message.

--- a/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
+++ b/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
@@ -81,6 +81,8 @@ public class RolesAndPermissionsHandler implements Serializable {
 
     private static final String ROLES_ROOT = "/roles";
 
+    private static final String ROLE_NAME_FIELD = "roleName";
+
     @Autowired
     private transient RoleTypeConfiguration roleTypes;
 
@@ -218,9 +220,9 @@ public class RolesAndPermissionsHandler implements Serializable {
             }
             roleToCopy = null;
         }
-        if (roleToCopy == null || !roleToCopy.isNodeType("jnt:role")
+        if (roleToCopy == null || !roleToCopy.isNodeType(Constants.JAHIANT_ROLE)
                 || !isUnderRolesRoot(roleToCopy.getParent().getPath())) {
-            messageContext.addMessage(new MessageBuilder().source("roleName")
+            messageContext.addMessage(new MessageBuilder().source(ROLE_NAME_FIELD)
                     .error()
                     .code("rolesmanager.rolesAndPermissions.role.cannotBeCopied")
                     .build());
@@ -238,7 +240,7 @@ public class RolesAndPermissionsHandler implements Serializable {
         boolean copyWithSubRoles = StringUtils.isNotEmpty(deepCopy);
         while (iterator.hasNext()) {
             JCRNodeWrapper subNode = (JCRNodeWrapper) iterator.next();
-            if (subNode.isNodeType("jnt:role")) {
+            if (subNode.isNodeType(Constants.JAHIANT_ROLE)) {
                 if (copyWithSubRoles) {
                     renameSubRole(subNode, newRoleName);
                 } else {
@@ -250,7 +252,7 @@ public class RolesAndPermissionsHandler implements Serializable {
         currentUserSession.save();
 
         if (copy) {
-            messageContext.addMessage(new MessageBuilder().source("roleName")
+            messageContext.addMessage(new MessageBuilder().source(ROLE_NAME_FIELD)
                     .info()
                     .code("rolesmanager.rolesAndPermissions.successfullyCopied")
                     .args(roleToCopy.getName(), newRoleName)
@@ -261,8 +263,7 @@ public class RolesAndPermissionsHandler implements Serializable {
     }
 
     private static boolean isUnderRolesRoot(String path) {
-        // a top-level role's parent IS /roles, so the exact match matters as much as the prefix;
-        // the trailing slash keeps /rolesomething out
+        // exact match for a top-level role, trailing slash so /rolesomething stays out
         return ROLES_ROOT.equals(path) || path.startsWith(ROLES_ROOT + "/");
     }
 
@@ -280,7 +281,7 @@ public class RolesAndPermissionsHandler implements Serializable {
 
     private RoleBean createRoleBean(JCRNodeWrapper role, boolean getPermissions, boolean getSubRoles) throws RepositoryException {
         RoleBean roleBean = new RoleBean();
-        JCRNodeWrapper parentRole = JCRContentUtils.getParentOfType(role, "jnt:role");
+        JCRNodeWrapper parentRole = JCRContentUtils.getParentOfType(role, Constants.JAHIANT_ROLE);
         final String uuid = role.getIdentifier();
         roleBean.setUuid(uuid);
         roleBean.setParentUuid(parentRole != null ? parentRole.getIdentifier() : null);
@@ -366,7 +367,7 @@ public class RolesAndPermissionsHandler implements Serializable {
 
         // sub-roles
         if (getSubRoles) {
-            final List<JCRNodeWrapper> subRoles = JCRContentUtils.getNodes(role, "jnt:role");
+            final List<JCRNodeWrapper> subRoles = JCRContentUtils.getNodes(role, Constants.JAHIANT_ROLE);
             final List<RoleBean> subRoleBeans = new ArrayList<RoleBean>(subRoles.size());
             for (JCRNodeWrapper subRole : subRoles) {
                 subRoleBeans.add(createRoleBean(subRole, false, false));
@@ -433,7 +434,7 @@ public class RolesAndPermissionsHandler implements Serializable {
 
     private boolean testRoleName(String roleName, MessageContext messageContext, JCRSessionWrapper currentUserSession) throws RepositoryException {
         if (StringUtils.isEmpty(roleName)) {
-            messageContext.addMessage(new MessageBuilder().source("roleName")
+            messageContext.addMessage(new MessageBuilder().source(ROLE_NAME_FIELD)
                     .error()
                     .code("rolesmanager.rolesAndPermissions.role.noName")
                     .build());
@@ -441,7 +442,7 @@ public class RolesAndPermissionsHandler implements Serializable {
         }
 
         if (roleExists(roleName, currentUserSession)) {
-            messageContext.addMessage(new MessageBuilder().source("roleName")
+            messageContext.addMessage(new MessageBuilder().source(ROLE_NAME_FIELD)
                     .error()
                     .code("rolesmanager.rolesAndPermissions.role.exists")
                     .build());
@@ -475,7 +476,7 @@ public class RolesAndPermissionsHandler implements Serializable {
         } else {
             parent = currentUserSession.getNodeByIdentifier(parentRoleId);
         }
-        JCRNodeWrapper role = parent.addNode(roleName, "jnt:role");
+        JCRNodeWrapper role = parent.addNode(roleName, Constants.JAHIANT_ROLE);
         RoleType roleType = roleTypes.get(roleTypeString);
         role.setProperty("j:roleGroup", roleType.getName());
         role.setProperty("j:privilegedAccess", roleType.isPrivileged());

--- a/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
+++ b/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
@@ -79,6 +79,8 @@ public class RolesAndPermissionsHandler implements Serializable {
 
     private static final String OTHER_PERMISSIONS_GROUP_MAME= "other";
 
+    private static final String ROLES_ROOT = "/roles";
+
     @Autowired
     private transient RoleTypeConfiguration roleTypes;
 
@@ -204,47 +206,57 @@ public class RolesAndPermissionsHandler implements Serializable {
     }
 
     public boolean copyRole(final String roleName, final String deepCopy, final String uuid, final MessageContext messageContext) throws RepositoryException {
-        final JCRSessionWrapper currentUserSession = getSession();
-        boolean copy = JCRTemplate.getInstance().doExecuteWithSystemSessionAsUser(currentUserSession.getUser(), currentUserSession.getWorkspace().getName(), null, new JCRCallback<Boolean>() {
-            @Override
-            public Boolean doInJCR(JCRSessionWrapper session) throws RepositoryException {
-                JCRNodeWrapper roleToCopy = session.getNodeByIdentifier(uuid);
+        JCRSessionWrapper currentUserSession = getSession();
 
-                String newRoleName = StringUtils.isNotEmpty(roleName) ? JCRContentUtils.generateNodeName(roleName) : roleName;
-                if (!testRoleName(newRoleName, messageContext, session)) {
-                    return false;
+        JCRNodeWrapper roleToCopy = currentUserSession.getNodeByIdentifier(uuid);
+        // the identifier comes from the request: it must designate a role, and the copy must land
+        // where roles live — this is the same node, in the same place, that addRole() would create
+        if (!roleToCopy.isNodeType("jnt:role") || !isUnderRolesRoot(roleToCopy.getParent().getPath())) {
+            messageContext.addMessage(new MessageBuilder().source("roleName")
+                    .error()
+                    .code("rolesmanager.rolesAndPermissions.role.cannotBeCopied")
+                    .build());
+            return false;
+        }
+
+        String newRoleName = StringUtils.isNotEmpty(roleName) ? JCRContentUtils.generateNodeName(roleName) : roleName;
+        if (!testRoleName(newRoleName, messageContext, currentUserSession)) {
+            return false;
+        }
+
+        // the copy runs on the caller's session, as addRole() already does for the node it creates
+        boolean copy = roleToCopy.copy(roleToCopy.getParent().getPath(), newRoleName);
+        JCRNodeWrapper copiedNode = currentUserSession.getNode(roleToCopy.getParent().getPath() + "/" + newRoleName);
+        NodeIterator iterator = copiedNode.getNodes();
+        boolean copyWithSubRoles = StringUtils.isNotEmpty(deepCopy);
+        while (iterator.hasNext()) {
+            JCRNodeWrapper subNode = (JCRNodeWrapper) iterator.next();
+            if (subNode.isNodeType("jnt:role")) {
+                if (copyWithSubRoles) {
+                    renameSubRole(subNode, newRoleName);
+                } else {
+                    subNode.remove();
                 }
-
-                boolean copy = roleToCopy.copy(roleToCopy.getParent().getPath(), newRoleName);
-                JCRNodeWrapper copiedNode = session.getNode(roleToCopy.getParent().getPath() + "/" + newRoleName);
-                NodeIterator iterator = copiedNode.getNodes();
-                boolean copyWithSubRoles = StringUtils.isNotEmpty(deepCopy);
-                while (iterator.hasNext()) {
-                    JCRNodeWrapper subNode = (JCRNodeWrapper) iterator.next();
-                    if (subNode.isNodeType("jnt:role")) {
-                        if (copyWithSubRoles) {
-                            renameSubRole(subNode, newRoleName);
-                        } else {
-                            subNode.remove();
-                        }
-                    }
-                }
-
-                session.save();
-
-                if (copy) {
-                    messageContext.addMessage(new MessageBuilder().source("roleName")
-                            .info()
-                            .code("rolesmanager.rolesAndPermissions.successfullyCopied")
-                            .args(roleToCopy.getName(), newRoleName)
-                            .build());
-                }
-
-                return copy;
             }
-        });
+        }
+
+        currentUserSession.save();
+
+        if (copy) {
+            messageContext.addMessage(new MessageBuilder().source("roleName")
+                    .info()
+                    .code("rolesmanager.rolesAndPermissions.successfullyCopied")
+                    .args(roleToCopy.getName(), newRoleName)
+                    .build());
+        }
 
         return copy;
+    }
+
+    private static boolean isUnderRolesRoot(String path) {
+        // a top-level role's parent IS /roles, so the exact match matters as much as the prefix;
+        // the trailing slash keeps /rolesomething out
+        return ROLES_ROOT.equals(path) || path.startsWith(ROLES_ROOT + "/");
     }
 
     protected void renameSubRole(JCRNodeWrapper subNode, String newRoleName) throws RepositoryException {

--- a/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
+++ b/src/main/java/org/jahia/modules/rolesmanager/RolesAndPermissionsHandler.java
@@ -208,10 +208,18 @@ public class RolesAndPermissionsHandler implements Serializable {
     public boolean copyRole(final String roleName, final String deepCopy, final String uuid, final MessageContext messageContext) throws RepositoryException {
         JCRSessionWrapper currentUserSession = getSession();
 
-        JCRNodeWrapper roleToCopy = currentUserSession.getNodeByIdentifier(uuid);
-        // the identifier comes from the request: it must designate a role, and the copy must land
-        // where roles live — this is the same node, in the same place, that addRole() would create
-        if (!roleToCopy.isNodeType("jnt:role") || !isUnderRolesRoot(roleToCopy.getParent().getPath())) {
+        // a copy lands beside its source, so the source must be a role that lives under /roles
+        JCRNodeWrapper roleToCopy;
+        try {
+            roleToCopy = currentUserSession.getNodeByIdentifier(uuid);
+        } catch (ItemNotFoundException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Cannot find role " + uuid, e);
+            }
+            roleToCopy = null;
+        }
+        if (roleToCopy == null || !roleToCopy.isNodeType("jnt:role")
+                || !isUnderRolesRoot(roleToCopy.getParent().getPath())) {
             messageContext.addMessage(new MessageBuilder().source("roleName")
                     .error()
                     .code("rolesmanager.rolesAndPermissions.role.cannotBeCopied")
@@ -224,7 +232,6 @@ public class RolesAndPermissionsHandler implements Serializable {
             return false;
         }
 
-        // the copy runs on the caller's session, as addRole() already does for the node it creates
         boolean copy = roleToCopy.copy(roleToCopy.getParent().getPath(), newRoleName);
         JCRNodeWrapper copiedNode = currentUserSession.getNode(roleToCopy.getParent().getPath() + "/" + newRoleName);
         NodeIterator iterator = copiedNode.getNodes();

--- a/src/main/resources/resources/JahiaRolesManager_de.properties
+++ b/src/main/resources/resources/JahiaRolesManager_de.properties
@@ -39,6 +39,7 @@ rolesmanager.rolesAndPermissions.role.add.name=Rollenname
 rolesmanager.rolesAndPermissions.role.delete=Rolle(n) löschen
 rolesmanager.rolesAndPermissions.role.delete.confirm=Wollen Sie wirklich die folgende Rolle(n) löschen?
 rolesmanager.rolesAndPermissions.role.exists=Eine Rolle mit demselben Namen ist bereits vorhanden
+rolesmanager.rolesAndPermissions.role.cannotBeCopied=Diese Rolle kann nicht kopiert werden
 rolesmanager.rolesAndPermissions.role.noName=Sie müssen einen Rollennamen eingeben
 rolesmanager.rolesAndPermissions.roleDetails=Rollendetails
 rolesmanager.rolesAndPermissions.roleType.edit_role=Bearbeitungsmodus-Rollen

--- a/src/main/resources/resources/JahiaRolesManager_en.properties
+++ b/src/main/resources/resources/JahiaRolesManager_en.properties
@@ -39,6 +39,7 @@ rolesmanager.rolesAndPermissions.role.add.name=Role name
 rolesmanager.rolesAndPermissions.role.delete=Delete role(s)
 rolesmanager.rolesAndPermissions.role.delete.confirm=Do you really want to delete the following role(s)?
 rolesmanager.rolesAndPermissions.role.exists=A role with the same name already exists
+rolesmanager.rolesAndPermissions.role.cannotBeCopied=This role cannot be copied
 rolesmanager.rolesAndPermissions.role.noName=You must specify a role name
 rolesmanager.rolesAndPermissions.roleDetails=Role details
 rolesmanager.rolesAndPermissions.roleType.edit_role=Edit roles

--- a/src/main/resources/resources/JahiaRolesManager_fr.properties
+++ b/src/main/resources/resources/JahiaRolesManager_fr.properties
@@ -39,6 +39,7 @@ rolesmanager.rolesAndPermissions.role.add.name=Nom du rôle
 rolesmanager.rolesAndPermissions.role.delete=Supprimer rôle(s)
 rolesmanager.rolesAndPermissions.role.delete.confirm=Voulez-vous vraiment supprimer le(s) rôle(s) suivant(s)?
 rolesmanager.rolesAndPermissions.role.exists=Un rôle portant le même nom existe déjà
+rolesmanager.rolesAndPermissions.role.cannotBeCopied=Ce rôle ne peut pas être copié
 rolesmanager.rolesAndPermissions.role.noName=Veuillez spécifier un nom pour le rôle
 rolesmanager.rolesAndPermissions.roleDetails=Détails du rôle
 rolesmanager.rolesAndPermissions.roleType.edit_role=rôles d'édition


### PR DESCRIPTION
## Summary

`RolesAndPermissionsHandler` creates role nodes from two places — `addRole()` and `copyRole()` — and
both build them the same way: on the caller's session, as a `jnt:role`, under `/roles`. Whatever the
"Add" button asks of the operator, the "Copy" button asks too.

## Change

`copyRole()` runs on the caller's session, like `addRole()`. `renameSubRole()` needs nothing of its
own, since it already works from `subNode.getSession()`.

Three conditions on the identifier that arrives with the form:

- it must resolve on the caller's session;
- it must designate a `jnt:role`;
- its parent must be `/roles` or below.

Any of the three failing produces the module's usual `MessageContext` error, with a new key added to
the three locale files (`en`, `fr`, `de`, all kept in their existing ISO-8859-1 encoding).

`isUnderRolesRoot()` tests the exact path **and** the prefix with a trailing slash — a top-level
role's parent is `/roles` itself, so an exact match is needed for the nominal case, and the trailing
slash keeps a sibling like `/rolesomething` out.

Error handling matches `addRole()`: if the operator lacks the rights for the write, the JCR exception
surfaces the same way it does there. Catching it in one of the two and not the other would leave the
two paths out of step.

## Verification

Exercised end to end on a running instance (`jahia-ee-dev:8-SNAPSHOT`, the image the module's CI
uses): the copy transition goes through the caller's session, so it answers to the same JCR
authorization as the handler's other writes. An account without write rights under `/roles` gets the
refusal at `save()` and `/roles` is left unchanged, which is the behavior the rest of the handler
already has.

`mvn compile` passes. The module has no test harness (no `src/test`, no Cypress directory, and its
CI runs build, static analysis, Sonar and signature only), so there is no suite to extend here.

