### PR TITLE
fix: require the roles screen's own permission rather than the aggregate one

### DIFF
--- a/.chachalog/mnkkRGZ.md
+++ b/.chachalog/mnkkRGZ.md
@@ -2,4 +2,4 @@
 rolesmanager: patch
 ---
 
-Render the roles and permissions screen only for server administrators
+Render the roles and permissions screen for the administrators its settings template requires.

--- a/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.properties
+++ b/src/main/resources/jnt_serverSettingsRolesAndPermissions/html/serverSettingsRolesAndPermissions.properties
@@ -3,8 +3,13 @@
 # regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
 # and it propagates to every view variant via the default view's properties.
 #
-# `admin` rather than the finer `adminRoles`: `admin` ships in core (root-permissions.xml) and is what
-# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
-# instance resolves to false — which would fail closed for administrators too. The finer requirement still
-# applies on the administration route via the template.
-requirePermissions=admin
+# `adminRoles` is what this screen's own hosting templates declare (`j:requiredPermissionNames` on
+# `rolesAndPermissions` and `rolesAndPermissions-jahia-anthracite`), so the component and the template now
+# state the same requirement. This module's `permissions.xml` registers `adminRoles` as a child of the core
+# `admin` permission, and Jahia aggregation runs downwards only: a role granted `admin` therefore still
+# holds `adminRoles`, while a role narrowed to the screens it administers keeps this one. Requiring the
+# aggregate `admin` here would refuse that narrowed role a screen its own template grants.
+#
+# The permission resolves wherever this screen can render, because the module that ships the screen ships
+# the permission.
+requirePermissions=adminRoles


### PR DESCRIPTION
## Summary

The roles and permissions screen requires the permission its own settings template declares, `adminRoles`, instead of the aggregate `admin`.

## Why

`requirePermissions` on the view is read by `TemplatePermissionCheckFilter` before the view runs, and it applies on every render path. That part is unchanged and is still what makes the requirement travel with the component.

The value was the problem. Jahia permission aggregation runs downwards only: a grant of `admin` implies `adminRoles`, but a role that names `adminRoles` does not hold `admin`. The role editor exposes those child permissions one by one. A server-administration role narrowed to the screens it administers was therefore refused this screen. Its own hosting templates grant it: `rolesAndPermissions` and `rolesAndPermissions-jahia-anthracite` both declare `j:requiredPermissionNames="adminRoles"`. The component and the template disagreed, and the component was the stricter of the two.

The comment in this file gave a reason for choosing `admin`. A module-contributed permission that is not registered on an instance resolves to `false`, and that would fail closed for administrators too. The reason does not hold for this screen. `adminRoles` is registered by this module's own `permissions.xml`. The module that ships the screen ships the permission, so the permission is present wherever the screen can render.

## Change

One value in one file: `requirePermissions=admin` becomes `requirePermissions=adminRoles`.

The comment above it now records why the per-screen permission is correct here, so the choice is not reversed later for the reason given above.

## Manual validation before vs after

This module ships no `tests/` suite, so the procedure is here. Run it against the base branch for the before, and against this branch for the after.

Prerequisites:

- Narrow a server-administration role to the screen's own permission. Untick the aggregate `admin`, then tick `administrationAccess` and `adminRoles`. Read the role back: `j:permissionNames` must list `adminRoles` and must not list `admin`.
- Use an account that holds that role at the repository root.

Procedure: as that account, open Administration and then Roles and permissions, at `/cms/adminframe/default/en/settings.rolesAndPermissions.html`.

Expected on this branch: the roles and permissions screen renders. Expected on the base branch: the screen is empty, although the caller holds `adminRoles`, which is what the hosting template declares.

## Verification

- The change is data only, so there is nothing to compile. The checks that matter were made against the mechanism instead.
- `adminRoles` is declared in this module's `src/main/import/permissions.xml`, as a child of `admin`.
- Both hosting templates declare `j:requiredPermissionNames="adminRoles"`, so the component now states the same requirement as the template.
- Core evaluates `requirePermissions` with `node.hasPermission(perm)` on the component node, which lives under `/modules/`. A role granted at the repository root holds its permissions there by inheritance, so `adminRoles` resolves for the narrowed role.
- This is the only view properties file in the module that sets `requirePermissions`, and the default view propagates it to the other variants.

## Changelog

The pending fragment for this screen is amended in place. A second fragment would put two entries for one behaviour in the same release notes, and the older entry describes behaviour that never shipped.
